### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Managing the cart of your Laravel application is a breeze",
     "require": {
         "php": ">=7.0",
-        "illuminate/support": "^5.5"
+        "illuminate/support": "5.5.*"
     },
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
Laravel doesn't follow semver. So having `^5.x`, `5.*` or `>=5.x` will mean that composer will install a future version even though that version breaks the package.